### PR TITLE
BENCH-395: Refactor Tags endpoints

### DIFF
--- a/src/Answer.King.Api/RequestModels/Tag.cs
+++ b/src/Answer.King.Api/RequestModels/Tag.cs
@@ -5,4 +5,6 @@ public record Tag
     public string Name { get; init; } = null!;
 
     public string Description { get; init; } = null!;
+
+    public List<long> Products { get; init; } = null!;
 }

--- a/src/Answer.King.Api/Services/CategoryService.cs
+++ b/src/Answer.King.Api/Services/CategoryService.cs
@@ -43,11 +43,8 @@ public class CategoryService : ICategoryService
 
         foreach (var productId in createCategory.Products)
         {
-            var product = await this.Products.GetOne(productId);
-            if (product == null)
-            {
-                throw new CategoryServiceException("The provided product id is not valid.");
-            }
+            var product = await this.Products.GetOne(productId) ??
+                          throw new CategoryServiceException("The provided product id is not valid.");
 
             products.Add(product);
 
@@ -78,15 +75,12 @@ public class CategoryService : ICategoryService
         }
 
         var categoryProducts = await this.Products.GetByCategoryId(categoryId);
-        var newProducts = updateCategory.Products.Where(p => !categoryProducts.Any(p2 => p2.Id == p));
+        var newProducts = updateCategory.Products.Where(p => categoryProducts.All(p2 => p2.Id != p));
 
         foreach (var updateId in newProducts)
         {
-            var product = await this.Products.GetOne(updateId);
-            if (product == null)
-            {
-                throw new CategoryServiceException("The provided product id is not valid.");
-            }
+            var product = await this.Products.GetOne(updateId) ??
+                          throw new CategoryServiceException("The provided product id is not valid.");
 
             products.Add(product);
 
@@ -134,11 +128,8 @@ public class CategoryService : ICategoryService
 
     private async Task RemoveProductFromCategory(Product product)
     {
-        var oldCategory = await this.Categories.GetOne(product.Category.Id);
-        if (oldCategory == null)
-        {
-            throw new CategoryServiceException("Failed to remove product from old category.");
-        }
+        var oldCategory = await this.Categories.GetOne(product.Category.Id) ??
+                          throw new CategoryServiceException("Failed to remove product from old category.");
 
         oldCategory.RemoveProduct(new ProductId(product.Id));
         await this.Categories.Save(oldCategory);

--- a/src/Answer.King.Api/Services/ITagService.cs
+++ b/src/Answer.King.Api/Services/ITagService.cs
@@ -15,8 +15,4 @@ public interface ITagService
     Task<Tag?> RetireTag(long tagId);
 
     Task<Tag?> UpdateTag(long tagId, RequestModels.Tag updateTag);
-
-    Task<Tag?> AddProducts(long tagId, RequestModels.TagProducts addProducts);
-
-    Task<Tag?> RemoveProducts(long tagId, RequestModels.TagProducts removeProducts);
 }

--- a/src/Answer.King.Api/Services/PaymentService.cs
+++ b/src/Answer.King.Api/Services/PaymentService.cs
@@ -33,12 +33,8 @@ public class PaymentService : IPaymentService
 
     public async Task<Payment> MakePayment(RequestModels.Payment makePayment)
     {
-        var order = await this.Orders.GetOne(makePayment.OrderId);
-
-        if (order == null)
-        {
-            throw new PaymentServiceException($"No order found for given order id: {makePayment.OrderId}.");
-        }
+        var order = await this.Orders.GetOne(makePayment.OrderId) ??
+                    throw new PaymentServiceException($"No order found for given order id: {makePayment.OrderId}.");
 
         try
         {

--- a/src/Answer.King.Api/Services/ProductService.cs
+++ b/src/Answer.King.Api/Services/ProductService.cs
@@ -42,12 +42,8 @@ public class ProductService : IProductService
 
     public async Task<Product> CreateProduct(RequestModels.Product createProduct)
     {
-        var category = await this.Categories.GetOne(createProduct.CategoryId);
-
-        if (category == null)
-        {
-            throw new ProductServiceException("The provided product category Id is not valid.");
-        }
+        var category = await this.Categories.GetOne(createProduct.CategoryId) ??
+                       throw new ProductServiceException("The provided product category Id is not valid.");
 
         var product = new Product(
             createProduct.Name,
@@ -83,19 +79,11 @@ public class ProductService : IProductService
 
         if (product.Category.Id != updateProduct.CategoryId)
         {
-            var category = await this.Categories.GetOne(updateProduct.CategoryId);
+            var category = await this.Categories.GetOne(updateProduct.CategoryId) ??
+                           throw new ProductServiceException("The provided product category Id is not valid.");
 
-            if (category == null)
-            {
-                throw new ProductServiceException("The provided product category Id is not valid.");
-            }
-
-            var currentCategory = await this.Categories.GetOne(product.Category.Id);
-
-            if (currentCategory == null)
-            {
-                throw new ProductServiceException("The current category is not valid");
-            }
+            var currentCategory = await this.Categories.GetOne(product.Category.Id) ??
+                                  throw new ProductServiceException("The current category is not valid");
 
             currentCategory.RemoveProduct(new ProductId(product.Id));
 

--- a/src/Answer.King.Api/Services/TagService.cs
+++ b/src/Answer.King.Api/Services/TagService.cs
@@ -136,12 +136,8 @@ public class TagService : ITagService
 
         foreach (var productId in products)
         {
-            var product = await this.Products.GetOne(productId);
-
-            if (product == null)
-            {
-                throw new TagServiceException($"The provided product id is not valid: {productId}");
-            }
+            var product = await this.Products.GetOne(productId) ??
+                          throw new TagServiceException($"The provided product id is not valid: {productId}");
 
             try
             {

--- a/src/Answer.King.Domain/Repositories/IBaseRepository.cs
+++ b/src/Answer.King.Domain/Repositories/IBaseRepository.cs
@@ -1,0 +1,10 @@
+﻿namespace Answer.King.Domain.Repositories;
+
+public interface IBaseRepository
+{
+    void BeginTransaction();
+
+    void CommitTransaction();
+
+    void RollbackTransaction();
+}

--- a/src/Answer.King.Domain/Repositories/ICategoryRepository.cs
+++ b/src/Answer.King.Domain/Repositories/ICategoryRepository.cs
@@ -2,7 +2,7 @@
 
 namespace Answer.King.Domain.Repositories;
 
-public interface ICategoryRepository : IAggregateRepository<Category>
+public interface ICategoryRepository : IAggregateRepository<Category>, IBaseRepository
 {
     Task<Category?> GetOne(string name);
 

--- a/src/Answer.King.Domain/Repositories/IOrderRepository.cs
+++ b/src/Answer.King.Domain/Repositories/IOrderRepository.cs
@@ -2,6 +2,6 @@
 
 namespace Answer.King.Domain.Repositories;
 
-public interface IOrderRepository : IAggregateRepository<Order>
+public interface IOrderRepository : IAggregateRepository<Order>, IBaseRepository
 {
 }

--- a/src/Answer.King.Domain/Repositories/IPaymentRepository.cs
+++ b/src/Answer.King.Domain/Repositories/IPaymentRepository.cs
@@ -2,7 +2,7 @@ using Answer.King.Domain.Repositories.Models;
 
 namespace Answer.King.Domain.Repositories;
 
-public interface IPaymentRepository
+public interface IPaymentRepository : IBaseRepository
 {
     Task<Payment> GetOne(long id);
 

--- a/src/Answer.King.Domain/Repositories/IProductRepository.cs
+++ b/src/Answer.King.Domain/Repositories/IProductRepository.cs
@@ -2,7 +2,7 @@ using Answer.King.Domain.Repositories.Models;
 
 namespace Answer.King.Domain.Repositories;
 
-public interface IProductRepository
+public interface IProductRepository : IBaseRepository
 {
     Task<Product?> GetOne(long id);
 

--- a/src/Answer.King.Domain/Repositories/ITagRepository.cs
+++ b/src/Answer.King.Domain/Repositories/ITagRepository.cs
@@ -2,7 +2,7 @@
 
 namespace Answer.King.Domain.Repositories;
 
-public interface ITagRepository : IAggregateRepository<Tag>
+public interface ITagRepository : IAggregateRepository<Tag>, IBaseRepository
 {
     Task<Tag?> GetOne(string name);
 }

--- a/src/Answer.King.Infrastructure/Repositories/BaseRepository.cs
+++ b/src/Answer.King.Infrastructure/Repositories/BaseRepository.cs
@@ -1,0 +1,29 @@
+﻿using Answer.King.Domain.Repositories;
+using LiteDB;
+
+namespace Answer.King.Infrastructure.Repositories;
+
+public abstract class BaseRepository : IBaseRepository
+{
+    protected BaseRepository(ILiteDbConnectionFactory connections)
+    {
+        this.Db = connections.GetConnection();
+    }
+
+    protected ILiteDatabase Db { get; }
+
+    public void BeginTransaction()
+    {
+        this.Db.BeginTrans();
+    }
+
+    public void CommitTransaction()
+    {
+        this.Db.Commit();
+    }
+
+    public void RollbackTransaction()
+    {
+        this.Db.Rollback();
+    }
+}

--- a/src/Answer.King.Infrastructure/Repositories/CategoryRepository.cs
+++ b/src/Answer.King.Infrastructure/Repositories/CategoryRepository.cs
@@ -7,13 +7,12 @@ using LiteDB;
 
 namespace Answer.King.Infrastructure.Repositories;
 
-public class CategoryRepository : ICategoryRepository
+public class CategoryRepository : BaseRepository, ICategoryRepository
 {
     public CategoryRepository(ILiteDbConnectionFactory connections)
+        : base(connections)
     {
-        var db = connections.GetConnection();
-
-        this.Collection = db.GetCollection<Category>();
+        this.Collection = this.Db.GetCollection<Category>();
         this.Collection.EnsureIndex("products");
     }
 

--- a/src/Answer.King.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Answer.King.Infrastructure/Repositories/OrderRepository.cs
@@ -6,13 +6,12 @@ using LiteDB;
 
 namespace Answer.King.Infrastructure.Repositories;
 
-public class OrderRepository : IOrderRepository
+public class OrderRepository : BaseRepository, IOrderRepository
 {
     public OrderRepository(ILiteDbConnectionFactory connections)
+        : base(connections)
     {
-        var db = connections.GetConnection();
-
-        this.Collection = db.GetCollection<Order>();
+        this.Collection = this.Db.GetCollection<Order>();
         this.Collection.EnsureIndex("lineItems.product._id");
     }
 

--- a/src/Answer.King.Infrastructure/Repositories/PaymentRepository.cs
+++ b/src/Answer.King.Infrastructure/Repositories/PaymentRepository.cs
@@ -6,13 +6,12 @@ using LiteDB;
 
 namespace Answer.King.Infrastructure.Repositories;
 
-public class PaymentRepository : IPaymentRepository
+public class PaymentRepository : BaseRepository, IPaymentRepository
 {
     public PaymentRepository(ILiteDbConnectionFactory connections)
+        : base(connections)
     {
-        var db = connections.GetConnection();
-
-        this.Collection = db.GetCollection<Payment>();
+        this.Collection = this.Db.GetCollection<Payment>();
     }
 
     private ILiteCollection<Payment> Collection { get; }

--- a/src/Answer.King.Infrastructure/Repositories/ProductRepository.cs
+++ b/src/Answer.King.Infrastructure/Repositories/ProductRepository.cs
@@ -8,15 +8,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Answer.King.Infrastructure.Repositories;
 
-public class ProductRepository : IProductRepository
+public class ProductRepository : BaseRepository, IProductRepository
 {
     private readonly ILogger<ProductRepository> logger;
 
     public ProductRepository(ILiteDbConnectionFactory connections, ILogger<ProductRepository> logger)
+        : base(connections)
     {
-        var db = connections.GetConnection();
-
-        this.Collection = db.GetCollection<Product>();
+        this.Collection = this.Db.GetCollection<Product>();
         this.Collection.EnsureIndex("categories");
 
         this.logger = logger;

--- a/src/Answer.King.Infrastructure/Repositories/TagRepository.cs
+++ b/src/Answer.King.Infrastructure/Repositories/TagRepository.cs
@@ -6,13 +6,12 @@ using LiteDB;
 
 namespace Answer.King.Infrastructure.Repositories;
 
-public class TagRepository : ITagRepository
+public class TagRepository : BaseRepository, ITagRepository
 {
     public TagRepository(ILiteDbConnectionFactory connections)
+        : base(connections)
     {
-        var db = connections.GetConnection();
-
-        this.Collection = db.GetCollection<Tag>();
+        this.Collection = this.Db.GetCollection<Tag>();
         this.Collection.EnsureIndex("products");
     }
 

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_InvalidDTO_ReturnsBadRequest.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_InvalidDTO_ReturnsBadRequest.verified.txt
@@ -4,6 +4,9 @@
   status: 400,
   traceId: {Scrubbed},
   errors: {
+    Products: [
+      The Products field is required.
+    ],
     Description: [
       The Description field is required.
     ]

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_ValidModelWithProducts_ReturnsNewTag.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_ValidModelWithProducts_ReturnsNewTag.verified.txt
@@ -1,0 +1,13 @@
+﻿{
+  Id: 4,
+  Name: Test Tag,
+  Description: Non-animal products,
+  CreatedOn: DateTime_1,
+  LastUpdated: DateTime_1,
+  Products: [
+    {
+      Value: 25
+    }
+  ],
+  Retired: false
+}

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_ValidModelWithProducts_ReturnsNewTag.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_ValidModelWithProducts_ReturnsNewTag.verified.txt
@@ -3,10 +3,10 @@
   Name: Test Tag,
   Description: Non-animal products,
   CreatedOn: DateTime_1,
-  LastUpdated: DateTime_1,
+  LastUpdated: DateTime_2,
   Products: [
     {
-      Value: 25
+      Value: 1
     }
   ],
   Retired: false

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_ValidModelWithRetiredProducts_ReturnsBadRequest_DoesNotPartiallyCreateTag.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_ValidModelWithRetiredProducts_ReturnsBadRequest_DoesNotPartiallyCreateTag.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc7231#section-6.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  traceId: {Scrubbed},
+  errors: {
+    products: [
+      Cannot add tag to retired product.
+    ]
+  }
+}

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PutTag_ValidDTOWithProducts_ReturnsModel.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PutTag_ValidDTOWithProducts_ReturnsModel.verified.txt
@@ -1,0 +1,13 @@
+﻿{
+  Id: 4,
+  Name: Test Tag,
+  Description: Edited Non-animal products,
+  CreatedOn: DateTime_1,
+  LastUpdated: DateTime_2,
+  Products: [
+    {
+      Value: 25
+    }
+  ],
+  Retired: false
+}

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.cs
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.cs
@@ -1,4 +1,5 @@
 using Answer.King.Api.IntegrationTests.Common;
+using Answer.King.Api.RequestModels;
 using Product = Answer.King.Api.IntegrationTests.Common.Models.Product;
 using Tag = Answer.King.Api.IntegrationTests.Common.Models.Tag;
 
@@ -39,6 +40,7 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Test Tag",
                     Description = "Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
@@ -67,46 +69,6 @@ public class TagsControllerTests : WebFixtures
     }
     #endregion
 
-    #region Get Products
-
-    [Fact]
-    public async Task<VerifyResult> GetProducts_TagExists_ReturnsProducts()
-    {
-        await this.AlbaHost.Scenario(_ =>
-        {
-            _.Post
-                .Json(new
-                {
-                    Name = "Test Tag",
-                    Description = "Non-animal products",
-                })
-                .ToUrl("/api/tags");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
-        });
-
-        var result = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Get.Url("/api/tags/1/products");
-            _.StatusCodeShouldBeOk();
-        });
-
-        var tag = result.ReadAsJson<IEnumerable<Product>>();
-        return await Verify(tag);
-    }
-
-    [Fact]
-    public async Task<VerifyResult> GetProducts_TagDoesNotExist_Returns404()
-    {
-        var result = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Get.Url("/api/tags/50/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.NotFound);
-        });
-
-        return await VerifyJson(result.ReadAsTextAsync(), this.verifySettings);
-    }
-    #endregion
-
     #region Post
     [Fact]
     public async Task<VerifyResult> PostTag_ValidModel_ReturnsNewTag()
@@ -118,6 +80,43 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Test Tag",
                     Description = "Non-animal products",
+                    Products = new List<long>(),
+                })
+                .ToUrl("/api/tags");
+            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
+        });
+
+        var tag = result.ReadAsJson<Tag>();
+        return await Verify(tag);
+    }
+
+    [Fact]
+    public async Task<VerifyResult> PostTag_ValidModelWithProducts_ReturnsNewTag()
+    {
+        var productResult = await this.AlbaHost.Scenario(_ =>
+        {
+            _.Post
+                .Json(new
+                {
+                    Name = "Burger",
+                    Description = "Juicy",
+                    Price = 1.50,
+                    CategoryId = new CategoryId(1),
+                })
+                .ToUrl("/api/products");
+            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
+        });
+
+        var product = productResult.ReadAsJson<Product>();
+
+        var result = await this.AlbaHost.Scenario(_ =>
+        {
+            _.Post
+                .Json(new
+                {
+                    Name = "Test Tag",
+                    Description = "Non-animal products",
+                    Products = new List<long> { product!.Id },
                 })
                 .ToUrl("/api/tags");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
@@ -154,6 +153,7 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Vegan",
                     Description = "Non-Animal Products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.BadRequest);
@@ -174,6 +174,7 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Test Tag",
                     Description = "Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
@@ -181,19 +182,71 @@ public class TagsControllerTests : WebFixtures
 
         var tag = postResult.ReadAsJson<Tag>();
 
-        var putResult = await this.AlbaHost.Scenario(_ =>
+        var result = await this.AlbaHost.Scenario(_ =>
         {
             _.Put
                 .Json(new
                 {
                     Name = "Test Tag",
                     Description = "Edited Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl($"/api/tags/{tag?.Id}");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.OK);
         });
 
-        var updatedTag = putResult.ReadAsJson<Tag>();
+        var updatedTag = result.ReadAsJson<Tag>();
+        return await Verify(updatedTag);
+    }
+
+    [Fact]
+    public async Task<VerifyResult> PutTag_ValidDTOWithProducts_ReturnsModel()
+    {
+        var productResult = await this.AlbaHost.Scenario(_ =>
+        {
+            _.Post
+                .Json(new
+                {
+                    Name = "Burger",
+                    Description = "Juicy",
+                    Price = 1.50,
+                    CategoryId = new CategoryId(1),
+                })
+                .ToUrl("/api/products");
+            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
+        });
+
+        var product = productResult.ReadAsJson<Product>();
+
+        var postResult = await this.AlbaHost.Scenario(_ =>
+        {
+            _.Post
+                .Json(new
+                {
+                    Name = "Test Tag",
+                    Description = "Non-animal products",
+                    Products = new List<long>(),
+                })
+                .ToUrl("/api/tags");
+            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
+        });
+
+        var tag = postResult.ReadAsJson<Tag>();
+
+        var result = await this.AlbaHost.Scenario(_ =>
+        {
+            _.Put
+                .Json(new
+                {
+                    Name = "Test Tag",
+                    Description = "Edited Non-animal products",
+                    Products = new List<long> { product!.Id },
+                })
+                .ToUrl($"/api/tags/{tag?.Id}");
+            _.StatusCodeShouldBe(System.Net.HttpStatusCode.OK);
+        });
+
+        var updatedTag = result.ReadAsJson<Tag>();
         return await Verify(updatedTag);
     }
 
@@ -206,6 +259,7 @@ public class TagsControllerTests : WebFixtures
                 .Json(new
                 {
                     Name = "Test Tag",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags/1");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.BadRequest);
@@ -224,6 +278,7 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Test Tag",
                     Description = "Edited Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags/50");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.NotFound);
@@ -242,148 +297,13 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Vegan",
                     Description = "Edited Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags/2");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.BadRequest);
         });
 
         return await VerifyJson(putResult.ReadAsTextAsync(), this.verifySettings);
-    }
-    #endregion
-
-    #region Put: Add Product
-    [Fact]
-    public async Task<VerifyResult> PutAddProducts_ValidDTO_ReturnsModel()
-    {
-        var postResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Post
-                .Json(new
-                {
-                    Name = "Test Tag",
-                    Description = "Non-animal products",
-                })
-                .ToUrl("/api/tags");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
-        });
-
-        var tag = postResult.ReadAsJson<Tag>();
-
-        var putResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Put
-                .Json(new
-                {
-                    Products = new List<long>(),
-                })
-                .ToUrl($"/api/tags/{tag?.Id}/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.OK);
-        });
-
-        var updatedTag = putResult.ReadAsJson<Tag>();
-        return await Verify(updatedTag);
-    }
-
-    [Fact]
-    public async Task<VerifyResult> PutAddProducts_InvalidDTO_ReturnsBadRequest()
-    {
-        var putResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Put
-                .Json(new
-                {
-                    Products = 1,
-                })
-                .ToUrl("/api/tags/1/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.BadRequest);
-        });
-
-        return await VerifyJson(putResult.ReadAsTextAsync(), this.verifySettings);
-    }
-
-    [Fact]
-    public async Task<VerifyResult> PutAddProducts_InvalidId_ReturnsNotFound()
-    {
-        var putResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Put
-                .Json(new
-                {
-                    Products = new List<long>(),
-                })
-                .ToUrl("/api/tags/50/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.NotFound);
-        });
-
-        return await VerifyJson(putResult.ReadAsTextAsync(), this.verifySettings);
-    }
-    #endregion
-
-    #region Delete: Remove Product
-    [Fact]
-    public async Task<VerifyResult> DeleteRemoveProducts_ValidDTO_ReturnsModel()
-    {
-        var postResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Post
-                .Json(new
-                {
-                    Name = "Test Tag",
-                    Description = "Non-animal products",
-                })
-                .ToUrl("/api/tags");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
-        });
-
-        var tag = postResult.ReadAsJson<Tag>();
-
-        var deleteResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Delete
-                .Json(new
-                {
-                    Products = new List<long>(),
-                })
-                .ToUrl($"/api/tags/{tag?.Id}/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.OK);
-        });
-
-        var updatedTag = deleteResult.ReadAsJson<Tag>();
-        return await Verify(updatedTag);
-    }
-
-    [Fact]
-    public async Task<VerifyResult> DeleteRemoveProducts_InvalidDTO_ReturnsBadRequest()
-    {
-        var deleteResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Delete
-                .Json(new
-                {
-                    Products = 1,
-                })
-                .ToUrl("/api/tags/1/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.BadRequest);
-        });
-
-        return await VerifyJson(deleteResult.ReadAsTextAsync(), this.verifySettings);
-    }
-
-    [Fact]
-    public async Task<VerifyResult> DeleteRemoveProducts_InvalidId_ReturnsNotFound()
-    {
-        var deleteResult = await this.AlbaHost.Scenario(_ =>
-        {
-            _.Delete
-                .Json(new
-                {
-                    Products = new List<long>(),
-                })
-                .ToUrl("/api/tags/50/products");
-            _.StatusCodeShouldBe(System.Net.HttpStatusCode.NotFound);
-        });
-
-        return await VerifyJson(deleteResult.ReadAsTextAsync(), this.verifySettings);
     }
     #endregion
 
@@ -411,6 +331,7 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Test Tag",
                     Description = "Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);
@@ -436,6 +357,7 @@ public class TagsControllerTests : WebFixtures
                 {
                     Name = "Test Tag",
                     Description = "Non-animal products",
+                    Products = new List<long>(),
                 })
                 .ToUrl("/api/tags");
             _.StatusCodeShouldBe(System.Net.HttpStatusCode.Created);

--- a/tests/Answer.King.Test.Common/CustomAsserts/AssertController.cs
+++ b/tests/Answer.King.Test.Common/CustomAsserts/AssertController.cs
@@ -33,12 +33,8 @@ public static class AssertController
     {
         var method = typeof(TController).GetMethod(methodName);
 
-        var attr = method?.GetCustomAttributes(typeof(TVerbAttribute), false).ToList();
-
-        if (attr == null)
-        {
-            throw new Exception("No custom attributes found.");
-        }
+        var attr = method?.GetCustomAttributes(typeof(TVerbAttribute), false).ToList() ??
+                   throw new Exception("No custom attributes found.");
 
         attr.AssertAttributeCount<TVerbAttribute>();
 
@@ -52,12 +48,8 @@ public static class AssertController
     {
         var method = typeof(TController).GetMethod(methodName);
 
-        var attr = method?.GetCustomAttributes(typeof(RouteAttribute), false).ToList();
-
-        if (attr == null)
-        {
-            throw new Exception("No custom attributes found.");
-        }
+        var attr = method?.GetCustomAttributes(typeof(RouteAttribute), false).ToList() ??
+                   throw new Exception("No custom attributes found.");
 
         attr.AssertAttributeCount<RouteAttribute>();
 

--- a/tests/Answer.King.Test.Common/CustomAsserts/CustomAssert.cs
+++ b/tests/Answer.King.Test.Common/CustomAsserts/CustomAssert.cs
@@ -24,12 +24,8 @@ public static class CustomAssert
     public static void MethodHasAttribute<T>(Type objectType, string methodName)
         where T : Attribute
     {
-        var method = objectType.GetMethod(methodName);
-
-        if (method == null)
-        {
-            throw new Exception($"Method {methodName} does not exist on type {objectType}.");
-        }
+        var method = objectType.GetMethod(methodName) ??
+                     throw new Exception($"Method {methodName} does not exist on type {objectType}.");
 
         var attr = method.GetCustomAttributes(typeof(T), false).ToList();
         attr.AssertAttributeCount<T>();
@@ -38,12 +34,8 @@ public static class CustomAssert
     public static void PropertyHasAttribute<T>(Type objectType, string propertyName)
         where T : Attribute
     {
-        var method = objectType.GetProperty(propertyName);
-
-        if (method == null)
-        {
-            throw new Exception($"Property {propertyName} does not exist on type {objectType}.");
-        }
+        var method = objectType.GetProperty(propertyName) ??
+                     throw new Exception($"Property {propertyName} does not exist on type {objectType}.");
 
         var attr = method.GetCustomAttributes(typeof(T), false).ToList();
         attr.AssertAttributeCount<T>();


### PR DESCRIPTION
Improving the match on the shared specification
Removed GET `tags/{id}/products` endpoint (required productIds on `tags` and `tags/{id}` endpoints already present)
Merged other `tags/{id}/products` endpoints into PUT `tags/{id}`
Updated tests to match new structure, verifying more exceptional cases