### PR TITLE
FIX: Dockerfile now builds using .csproj file

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN dotnet restore && dotnet publish -c Release -o out
+RUN dotnet restore && dotnet publish src/Answer.King.Api/Answer.King.Api.csproj -c Release -o out
 
 #build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0


### PR DESCRIPTION
There was an issue in production where the Microsoft.Extensions.DependencyModel package conflicted with Serilog due to a bug when building with the .sln file instead of targeting Answer.King.Api.csproj