### PR TITLE
Fixes to Tag Service

### DIFF
--- a/src/Answer.King.Domain/Repositories/Models/Product.cs
+++ b/src/Answer.King.Domain/Repositories/Models/Product.cs
@@ -64,7 +64,7 @@ public class Product
 
     public void AddTag(TagId tag)
     {
-        if (this.Retired & !this.Tags.Contains(tag))
+        if (this.Retired && !this.Tags.Contains(tag))
         {
             throw new ProductLifecycleException("Cannot add tag to retired product.");
         }
@@ -74,7 +74,7 @@ public class Product
 
     public void RemoveTag(TagId tag)
     {
-        if (this.Retired & this.Tags.Contains(tag))
+        if (this.Retired && this.Tags.Contains(tag))
         {
             throw new ProductLifecycleException("Cannot remove tag from retired product.");
         }
@@ -89,7 +89,7 @@ public class Product
 
     public void SetCategory(ProductCategory newCategory)
     {
-        if (this.Retired & this.Category != newCategory)
+        if (this.Retired && this.Category != newCategory)
         {
             throw new ProductLifecycleException("Can't add product to category. Product is retired");
         }

--- a/src/Answer.King.Domain/Repositories/Models/Product.cs
+++ b/src/Answer.King.Domain/Repositories/Models/Product.cs
@@ -64,7 +64,7 @@ public class Product
 
     public void AddTag(TagId tag)
     {
-        if (this.Retired)
+        if (this.Retired & !this.Tags.Contains(tag))
         {
             throw new ProductLifecycleException("Cannot add tag to retired product.");
         }
@@ -74,7 +74,7 @@ public class Product
 
     public void RemoveTag(TagId tag)
     {
-        if (this.Retired)
+        if (this.Retired & this.Tags.Contains(tag))
         {
             throw new ProductLifecycleException("Cannot remove tag from retired product.");
         }
@@ -89,7 +89,7 @@ public class Product
 
     public void SetCategory(ProductCategory newCategory)
     {
-        if (this.Retired)
+        if (this.Retired & this.Category != newCategory)
         {
             throw new ProductLifecycleException("Can't add product to category. Product is retired");
         }

--- a/tests/Answer.King.Domain.UnitTests/Repositories/Models/ProductTests.cs
+++ b/tests/Answer.King.Domain.UnitTests/Repositories/Models/ProductTests.cs
@@ -5,7 +5,7 @@ using Product = Answer.King.Domain.Repositories.Models.Product;
 using ProductCategory = Answer.King.Domain.Repositories.Models.ProductCategory;
 using TagId = Answer.King.Domain.Repositories.Models.TagId;
 
-namespace Answer.King.Domain.UnitTests.Orders;
+namespace Answer.King.Domain.UnitTests.Repositories.Models;
 
 [TestCategory(TestType.Unit)]
 public class ProductTests

--- a/tests/Answer.King.Domain.UnitTests/Repositories/Models/ProductTests.cs
+++ b/tests/Answer.King.Domain.UnitTests/Repositories/Models/ProductTests.cs
@@ -1,0 +1,145 @@
+using Answer.King.Domain.Repositories.Models;
+using Answer.King.Test.Common.CustomTraits;
+using Xunit;
+using Product = Answer.King.Domain.Repositories.Models.Product;
+using ProductCategory = Answer.King.Domain.Repositories.Models.ProductCategory;
+using TagId = Answer.King.Domain.Repositories.Models.TagId;
+
+namespace Answer.King.Domain.UnitTests.Orders;
+
+[TestCategory(TestType.Unit)]
+public class ProductTests
+{
+    [Fact]
+    public void Product_IsRetired_AddTag_ThrowsProductLifecycleException()
+    {
+        // Arrange
+        const string name = "name";
+        const string description = "description";
+        const int price = 142;
+        var productCategory = new ProductCategory(1, "category name", "category description");
+        var product = new Product(
+            name,
+            description,
+            price,
+            productCategory);
+        var tagId = new TagId(1);
+        product.Retire();
+
+        // Act/Assert
+        Assert.Throws<ProductLifecycleException>(() => product.AddTag(tagId));
+    }
+
+    [Fact]
+    public void Product_IsRetired_ExistingTagAdded_ProductUnchanged()
+    {
+        // Arrange
+        const string name = "name";
+        const string description = "description";
+        const int price = 142;
+        var productCategory = new ProductCategory(1, "category name", "category description");
+        var product = new Product(
+            name,
+            description,
+            price,
+            productCategory);
+        var tagId = new TagId(1);
+        product.AddTag(tagId);
+        var expectedTags = new string(product.Tags.ToString());
+        product.Retire();
+
+        // Act
+        product.AddTag(tagId);
+
+        // Assert
+        Assert.Equal(product.Tags.ToString(), expectedTags);
+    }
+
+    [Fact]
+    public void Product_IsRetired_RemoveExistingTag_ThrowsProductLifecycleException()
+    {
+        // Arrange
+        const string name = "name";
+        const string description = "description";
+        const int price = 142;
+        var productCategory = new ProductCategory(1, "category name", "category description");
+        var product = new Product(
+            name,
+            description,
+            price,
+            productCategory);
+        var tagId = new TagId(1);
+        product.AddTag(tagId);
+        product.Retire();
+
+        // Act/Assert
+        Assert.Throws<ProductLifecycleException>(() => product.RemoveTag(tagId));
+    }
+
+    [Fact]
+    public void Product_IsRetired_RemoveUnassociatedTag_ProductUnchanged()
+    {
+        // Arrange
+        const string name = "name";
+        const string description = "description";
+        const int price = 142;
+        var productCategory = new ProductCategory(1, "category name", "category description");
+        var product = new Product(
+            name,
+            description,
+            price,
+            productCategory);
+        var tagId = new TagId(1);
+        var expectedTags = new string(product.Tags.ToString());
+
+        // Act
+        product.Retire();
+        product.RemoveTag(tagId);
+
+        // Assert
+        Assert.Equal(product.Tags.ToString(), expectedTags);
+    }
+
+    [Fact]
+    public void Product_IsRetired_CategoryAdded_ThrowsProductLifecycleException()
+    {
+        // Arrange
+        const string name = "name";
+        const string description = "description";
+        const int price = 142;
+        var oldCategory = new ProductCategory(1, "category name", "category description");
+        var newCategory = new ProductCategory(2, "category name", "category description");
+        var product = new Product(
+            name,
+            description,
+            price,
+            oldCategory);
+        product.Retire();
+
+        // Act/Assert
+        Assert.Throws<ProductLifecycleException>(() => product.SetCategory(newCategory));
+    }
+
+    [Fact]
+    public void Product_IsRetired_ExistingCategoryAdded_ProductUnchanged()
+    {
+        // Arrange
+        const string name = "name";
+        const string description = "description";
+        const int price = 142;
+        var productCategory = new ProductCategory(1, "category name", "category description");
+        var product = new Product(
+            name,
+            description,
+            price,
+            productCategory);
+        var expectedCategory = new string(product.Category.ToString());
+        product.Retire();
+
+        // Act
+        product.SetCategory(productCategory);
+
+        // Assert
+        Assert.Equal(product.Category.ToString(), expectedCategory);
+    }
+}


### PR DESCRIPTION
Currently for any tags with retired products, you cannot edit this tag via a `tags/id` `put` request. If you leave the retired tag in you get a "_Cannot add tag to retired product_" error and if you leave it out you get a ''_Cannot remove tag from retired product_." error.

I've stopped the tag service from adding products to tags if they are already associated. Also there is a function here that clearly was supposed to do the opposite (i.e. stop products that aren't in a tag from being removed) that I fixed.