### PR TITLE
BENCH-304: Set up Checkov analysis tool for scanning Terraform

### DIFF
--- a/.github/workflows/build-test-analyse.yml
+++ b/.github/workflows/build-test-analyse.yml
@@ -118,3 +118,21 @@ jobs:
             dotnet-sonarscanner begin /k:"${{ secrets.SONAR_PROJECT_KEY }}" /o:"${{ secrets.SONAR_ORG_KEY }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="./*/coverage.opencover.xml"
             dotnet build -c Release --no-restore
             dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+
+  checkov:
+    name: Checkov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.11
+
+      - name: Test Terraform with Checkov
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: terraform/
+          framework: terraform

--- a/.gitignore
+++ b/.gitignore
@@ -463,3 +463,6 @@ $RECYCLE.BIN/
 terraform.tfstate
 terraform.tfstate.backup
 terraform/env_variables.tf
+
+# Python venv
+.venv/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ For example - reportgenerator -reports:"C:\Users\HarryStead\Documents\AnswerKing
 
 [Learn more about .Net code coverage](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage?tabs=windows)
 
+## Terraform
+
+This project is currently hosted on AWS with Terraform being used to build, update and destroy the necessary resources as desired. The following instructions assume that you already have access to the AWS account and a working AWS CLI setup.
+
+Before being able to use Terraform, you'll need a copy of the gitignore'd env_variables.tf file from member of the team. This is currently being used to store secrets before we move to a more robust solution.
+
+Once you have that, you can preview Terraform's execution plan by running `terraform plan` and then, if you're happy with the preview, `terraform apply` to execute the plan.
+
+Since this is a bench project without real users, we should tear down the resources when they're not needed to save unnecessary costs. Running `terraform destroy` will destroy all of the resources that Terraform is currently managing. Note: This does not included resources which have been removed from Terraform's management such as the commented out block in `backend.tf`.
 
 ## Checkov Scanning For Terraform
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,40 @@ For example - reportgenerator -reports:"C:\Users\HarryStead\Documents\AnswerKing
 [Learn more about .Net code coverage](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage?tabs=windows)
 
 
+## Checkov Scanning For Terraform
+
+Checkov is used as part of the pipeline to check for common misconfigurations in our Terraform scripts.
+
+It can be ran locally to validate changes ahead of pushing if desired, assuming you have Python installed.
+
+---
+
+1. From a terminal window in the root directory of this repository, run the following to set up a virtual environment:
+
+`python -m venv .venv`
+
+2. Access this virtual environment by one of the following:
+
+- Git Bash: `. .venv/Scripts/activate`
+
+- cmd.exe: `.\.venv\Scripts\activate.bat`
+
+- Powershell: `.\.venv\Scripts\Activate.ps1`
+
+"(.venv)" should appear at the start of your current prompt in the terminal if this has worked.
+
+3. Run the following to install checkov to your virtual environment:
+
+`python -m pip install checkov`
+
+4. Once installed, run the following to scan the `terraform` directory:
+
+`checkov -d terraform/`
+
+5. When you're finished, the virtual environment can be left by closing the terminal or running the following:
+
+`deactivate`
+
+---
+
+On subsequent runs, you can skip steps 1 and 3.

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "log_group" {
+  #checkov:skip=CKV_AWS_158:TODO: encrypt logs in future security ticket
   name              = "${var.project_name}-logs"
   retention_in_days = var.aws_cloudwatch_retention_in_days
 

--- a/terraform/efs.tf
+++ b/terraform/efs.tf
@@ -1,6 +1,8 @@
 resource "aws_security_group" "efs_sg" {
-  name    = "${var.project_name}-efs-sg"
-  vpc_id  = module.vpc_subnet.vpc_id
+  #checkov:skip=CKV_AWS_23:TODO: Uncomment descriptions
+  name        = "${var.project_name}-efs-sg"
+  #description = "Security group for Elastic File System"
+  vpc_id      = module.vpc_subnet.vpc_id
 
   ingress {
     protocol        = "tcp"
@@ -8,10 +10,12 @@ resource "aws_security_group" "efs_sg" {
     to_port         = var.efs_port
     security_groups = [aws_security_group.ecs_sg.id]
     cidr_blocks     = [var.vpc_cidr]
+    #description     = "Allow access to the VPC on a dedicated EFS port"
   }
 }
 
 resource "aws_efs_file_system" "persistent" {
+  #checkov:skip=CKV_AWS_184:TODO: Encrypt EFS with Customer Managed Key in future security ticket
   encrypted = true
   tags = {
     Name = "${var.project_name}-efs-persistent"

--- a/terraform/efs.tf
+++ b/terraform/efs.tf
@@ -1,7 +1,6 @@
 resource "aws_security_group" "efs_sg" {
-  #checkov:skip=CKV_AWS_23:TODO: Uncomment descriptions
   name        = "${var.project_name}-efs-sg"
-  #description = "Security group for Elastic File System"
+  description = "Security group for Elastic File System"
   vpc_id      = module.vpc_subnet.vpc_id
 
   ingress {
@@ -10,7 +9,7 @@ resource "aws_security_group" "efs_sg" {
     to_port         = var.efs_port
     security_groups = [aws_security_group.ecs_sg.id]
     cidr_blocks     = [var.vpc_cidr]
-    #description     = "Allow access to the VPC on a dedicated EFS port"
+    description     = "Allow access to the VPC on a dedicated EFS port"
   }
 }
 

--- a/terraform/launch-config.tf
+++ b/terraform/launch-config.tf
@@ -20,6 +20,8 @@ data "template_file" "user_data" {
 }
 
 resource "aws_launch_configuration" "ecs_launch_config" {
+    #checkov:skip=CKV_AWS_79:TODO: Disable the Instance Metadata Service or enable it with proper configuration (v2)
+    #checkov:skip=CKV_AWS_8:TODO: Encrypt volume in future security ticket
     image_id             = data.aws_ami.ecs_ami.id
     iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
     security_groups      = [aws_security_group.ecs_sg.id]

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -21,16 +21,15 @@ resource "aws_route53_record" "dns_dotnet" {
 # Load Balancer
 
 resource "aws_lb" "load_balancer" {
+  #checkov:skip=CKV_AWS_150:Deletion protection is being left off for ease of running terraform destroy
+
   #checkov:skip=CKV_AWS_91:TODO: Add cloudwatch logging
   #checkov:skip=CKV2_AWS_20:TODO: Redirect HTTP to HTTPS at load balancer and remove HTTP handling afterwards in future security ticket
   name                             = "${var.project_name}-lb"
   internal                         = false
   load_balancer_type               = "network"
   ip_address_type                  = "ipv4"
-  #checkov:skip=CKV_AWS_152:TODO: Uncomment below
-  #enable_cross_zone_load_balancing = true
-  #checkov:skip=CKV_AWS_150:TODO: Uncomment below
-  #enable_deletion_protection       = true
+  enable_cross_zone_load_balancing = true
 
   subnet_mapping {
     subnet_id     = "${module.vpc_subnet.public_subnet_ids[0]}"

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,6 +1,7 @@
 # Elastic IP
 
 resource "aws_eip" "lb_eip" {
+  #checkov:skip=CKV2_AWS_19:IP is being used for load balancer
   vpc = true
 
   tags = {
@@ -20,10 +21,16 @@ resource "aws_route53_record" "dns_dotnet" {
 # Load Balancer
 
 resource "aws_lb" "load_balancer" {
-  name               = "${var.project_name}-lb"
-  internal           = false
-  load_balancer_type = "network"
-  ip_address_type    = "ipv4"
+  #checkov:skip=CKV_AWS_91:TODO: Add cloudwatch logging
+  #checkov:skip=CKV2_AWS_20:TODO: Redirect HTTP to HTTPS at load balancer and remove HTTP handling afterwards in future security ticket
+  name                             = "${var.project_name}-lb"
+  internal                         = false
+  load_balancer_type               = "network"
+  ip_address_type                  = "ipv4"
+  #checkov:skip=CKV_AWS_152:TODO: Uncomment below
+  #enable_cross_zone_load_balancing = true
+  #checkov:skip=CKV_AWS_150:TODO: Uncomment below
+  #enable_deletion_protection       = true
 
   subnet_mapping {
     subnet_id     = "${module.vpc_subnet.public_subnet_ids[0]}"
@@ -46,7 +53,7 @@ resource "aws_lb_target_group" "target_group" {
     Name = "${var.project_name}-lb-tg"
   }
 
-  lifecycle { 
+  lifecycle {
     create_before_destroy = true
     ignore_changes = [name]
   }
@@ -64,6 +71,7 @@ resource "aws_lb_listener" "listener" {
 }
 
 resource "aws_lb_listener" "listener_443" {
+  #checkov:skip=CKV_AWS_103:TODO: Add SSL policy to ensure TLS 1.2 or higher is being used in future security ticket
   load_balancer_arn = aws_lb.load_balancer.id
   port              = "443"
   protocol          = "TLS"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,6 +13,7 @@ module "vpc_subnet" {
 # Security Group: Defines network traffic rules for our ECS
 
 resource "aws_security_group" "ecs_sg" {
+  #checkov:skip=CKV_AWS_260:Allowing ingress from 0.0.0.0 for public HTTP(S) access
   name        = "${var.project_name}-ecs-sg"
   description = "Security group for ec2-sg"
   vpc_id       = module.vpc_subnet.vpc_id
@@ -33,11 +34,13 @@ resource "aws_security_group" "ecs_sg" {
     description = "HTTPS"
   }
 
+  #checkov:skip=CKV_AWS_23:TODO: Uncomment description
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    #description = "All traffic"
   }
 
   tags = {
@@ -106,7 +109,7 @@ resource "aws_ecs_task_definition" "aws_ecs_task" {
       "name": "${var.project_name}-container",
       "image": "${var.image_url}",
       "entryPoint": [],
-      
+
       "essential": true,
       "logConfiguration": {
         "logDriver": "awslogs",
@@ -143,10 +146,12 @@ resource "aws_ecs_task_definition" "aws_ecs_task" {
   network_mode             = "awsvpc"
   memory                   = "512"
   cpu                      = "256"
+
+  #checkov:skip=CKV_AWS_249:TODO: Determine if we should have separate role permissions for execution and task in future security ticket
   execution_role_arn       = aws_iam_role.ecs_task_role.arn
   task_role_arn            = aws_iam_role.ecs_task_role.arn
 
- volume {
+  volume {
     name = "${var.project_name}-ecs-efs-volume"
 
     efs_volume_configuration {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,13 +34,12 @@ resource "aws_security_group" "ecs_sg" {
     description = "HTTPS"
   }
 
-  #checkov:skip=CKV_AWS_23:TODO: Uncomment description
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-    #description = "All traffic"
+    description = "All traffic"
   }
 
   tags = {


### PR DESCRIPTION
Checkov is set up to run as part of the pipeline and instructions to run it locally (and common Terraform usage) have been added to README.md. An example of this pipeline run can be found here: https://github.com/AnswerConsulting/AnswerKing-CS/actions/runs/4205844464/jobs/7298513856

Some small changes have been made to the actual Terraform scripts, mostly it's adding skips for issues which we'll address in the security part of the upcoming sprint. This has been tested and since teared down.