### PR TITLE
BENCH-431: Clarify skip for checkov rule

### DIFF
--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -22,9 +22,9 @@ resource "aws_route53_record" "dns_dotnet" {
 
 resource "aws_lb" "load_balancer" {
   #checkov:skip=CKV_AWS_150:Deletion protection is being left off for ease of running terraform destroy
+  #checkov:skip=CKV2_AWS_20:Not required for our network load balancer, would be helpful for application load balancer instead
 
   #checkov:skip=CKV_AWS_91:TODO: Add cloudwatch logging
-  #checkov:skip=CKV2_AWS_20:TODO: Redirect HTTP to HTTPS at load balancer and remove HTTP handling afterwards in future security ticket
   name                             = "${var.project_name}-lb"
   internal                         = false
   load_balancer_type               = "network"


### PR DESCRIPTION
I've tested a few iterations of following this rule for upgrading HTTP requests to HTTPS but it looks like it's more intended for an application load balancer rather than the network load balancer which we're using here to manage internal TCP and TLS messages. As such, I've kept the skip and clarified the message to detail this reasoning.