### PR TITLE
Fix for name duplication error messages

### DIFF
--- a/src/Answer.King.Api/Controllers/CategoriesController.cs
+++ b/src/Answer.King.Api/Controllers/CategoriesController.cs
@@ -77,7 +77,7 @@ public class CategoriesController : ControllerBase
         if (namedCategory != null)
         {
             this.ModelState.AddModelError("category", "A category with this name already exists");
-            return this.BadRequest();
+            return this.ValidationProblem();
         }
 
         try
@@ -123,7 +123,7 @@ public class CategoriesController : ControllerBase
             if (namedCategory != null && namedCategory.Id != id)
             {
                 this.ModelState.AddModelError("category", "A category with this name already exists");
-                return this.BadRequest();
+                return this.ValidationProblem();
             }
 
             return this.Ok(category);

--- a/src/Answer.King.Api/Controllers/ProductsController.cs
+++ b/src/Answer.King.Api/Controllers/ProductsController.cs
@@ -78,7 +78,7 @@ public class ProductsController : ControllerBase
         if (namedProduct != null)
         {
             this.ModelState.AddModelError("product", "A product with this name already exists");
-            return this.BadRequest();
+            return this.ValidationProblem();
         }
 
         try
@@ -125,7 +125,7 @@ public class ProductsController : ControllerBase
             if (namedProduct != null && id != namedProduct.Id)
             {
                 this.ModelState.AddModelError("product", "A product with this name already exists");
-                return this.BadRequest();
+                return this.ValidationProblem();
             }
 
             return this.Ok(product);

--- a/src/Answer.King.Api/Controllers/TagsController.cs
+++ b/src/Answer.King.Api/Controllers/TagsController.cs
@@ -72,7 +72,7 @@ public class TagsController : ControllerBase
         if (namedTag != null)
         {
             this.ModelState.AddModelError("tag", "A tag with this name already exists");
-            return this.BadRequest();
+            return this.ValidationProblem();
         }
 
         try
@@ -109,7 +109,7 @@ public class TagsController : ControllerBase
         if (namedTag != null && id != namedTag.Id)
         {
             this.ModelState.AddModelError("tag", "A tag with this name already exists");
-            return this.BadRequest();
+            return this.ValidationProblem();
         }
 
         try

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/CategoriesControllerTests.PostCategory_DuplicateName_ReturnsBadRequest.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/CategoriesControllerTests.PostCategory_DuplicateName_ReturnsBadRequest.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   type: https://tools.ietf.org/html/rfc7231#section-6.5.1,
-  title: Bad Request,
+  title: One or more validation errors occurred.,
   status: 400,
-  traceId: {Scrubbed}
+  traceId: {Scrubbed},
+  errors: {
+    category: [
+      A category with this name already exists
+    ]
+  }
 }

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/CategoriesControllerTests.PutCategory_DuplicateName_ReturnsBadRequest.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/CategoriesControllerTests.PutCategory_DuplicateName_ReturnsBadRequest.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   type: https://tools.ietf.org/html/rfc7231#section-6.5.1,
-  title: Bad Request,
+  title: One or more validation errors occurred.,
   status: 400,
-  traceId: {Scrubbed}
+  traceId: {Scrubbed},
+  errors: {
+    category: [
+      A category with this name already exists
+    ]
+  }
 }

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/ProductsControllerTests.PostProduct_DuplicateName_ReturnsBadRequest.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/ProductsControllerTests.PostProduct_DuplicateName_ReturnsBadRequest.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   type: https://tools.ietf.org/html/rfc7231#section-6.5.1,
-  title: Bad Request,
+  title: One or more validation errors occurred.,
   status: 400,
-  traceId: {Scrubbed}
+  traceId: {Scrubbed},
+  errors: {
+    product: [
+      A product with this name already exists
+    ]
+  }
 }

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_DuplicateName_ReturnsBadRequest.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PostTag_DuplicateName_ReturnsBadRequest.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   type: https://tools.ietf.org/html/rfc7231#section-6.5.1,
-  title: Bad Request,
+  title: One or more validation errors occurred.,
   status: 400,
-  traceId: {Scrubbed}
+  traceId: {Scrubbed},
+  errors: {
+    tag: [
+      A tag with this name already exists
+    ]
+  }
 }

--- a/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PutTag_DuplicateName_ReturnsBadRequest.verified.txt
+++ b/tests/Answer.King.Api.IntegrationTests/Controllers/TagsControllerTests.PutTag_DuplicateName_ReturnsBadRequest.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   type: https://tools.ietf.org/html/rfc7231#section-6.5.1,
-  title: Bad Request,
+  title: One or more validation errors occurred.,
   status: 400,
-  traceId: {Scrubbed}
+  traceId: {Scrubbed},
+  errors: {
+    tag: [
+      A tag with this name already exists
+    ]
+  }
 }


### PR DESCRIPTION
Changed return type from BadRequest to ValidationProblem when name duplication occurs, as messages were not being returned with the errors